### PR TITLE
Add Laravel 6 as an accepted version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5"
+        "illuminate/support": "5-6"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
No big changes were made in Service Providers used by this library, so it is still valid with Laravel 6